### PR TITLE
Add svn to ottrpal image

### DIFF
--- a/ottrpal/Dockerfile
+++ b/ottrpal/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get install -y --no-install-recommends \
     vim \
     libglpk40 \
     curl \
-    gpg
+    gpg \
+    subversion
 
 # Install R
 RUN apt-get update && apt-get install -y r-base curl


### PR DESCRIPTION
It'd be easier if all handling items were handled by the ottrpal image. If we install svn on the ottrpal image then we can use the ottrpal image from transfer-rendered-files.yml github action and not have to worry about installing the subversion package whenever we use it. 