### PR TITLE
Retire phantomJS for chromote

### DIFF
--- a/ottrpal/Dockerfile
+++ b/ottrpal/Dockerfile
@@ -17,14 +17,5 @@ RUN apt-get install -y --no-install-recommends \
 RUN apt-get update && apt-get install -y r-base curl
 
 # Install R packages
-RUN Rscript -e  "install.packages('curl')"
+RUN Rscript -e  "install.packages(c('curl', 'chromote', 'webshot2'))"
 
-# Install phantomjs
-RUN apt-get update && apt-get install build-essential chrpath libssl-dev libxft-dev -y \
-  && apt-get install libfontconfig1 libfontconfig1-dev -y \
-  && cd ~ && export PHANTOM_JS="phantomjs-2.1.1-linux-x86_64" \
-  && wget https://github.com/Medium/phantomjs/releases/download/v2.1.1/$PHANTOM_JS.tar.bz2 \
-  && sudo tar xvjf $PHANTOM_JS.tar.bz2 \
-  && sudo mv $PHANTOM_JS /usr/local/share \
-  && sudo ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin \
-  && phantomjs --version


### PR DESCRIPTION
Associated with https://github.com/jhudsl/ottr-reports/pull/37

We will no longer being using webshot because its dependency phantomJS is totally deprecated. 

Instead we're moving to webshot2 which uses the dependency of "chromote" underneath the hood. 