### PR TITLE
Install dev version of ottrpal

### DIFF
--- a/ottrpal/Dockerfile
+++ b/ottrpal/Dockerfile
@@ -26,6 +26,6 @@ COPY github_package_list.tsv .
 
 # Install development version of ottrpal!
 RUN Rscript install_github.R \
-  --packages 'ottrpal' \
+  --packages github_package_list.tsv \
   --token git_token.txt
 

--- a/ottrpal/Dockerfile
+++ b/ottrpal/Dockerfile
@@ -21,6 +21,7 @@ RUN Rscript -e  "install.packages(c('curl', 'chromote', 'webshot2'))"
 
 # Copy over git token
 COPY git_token.txt .
+COPY install_github.R .
 
 # Install development version of ottrpal!
 RUN Rscript install_github.R \

--- a/ottrpal/Dockerfile
+++ b/ottrpal/Dockerfile
@@ -19,3 +19,11 @@ RUN apt-get update && apt-get install -y r-base curl
 # Install R packages
 RUN Rscript -e  "install.packages(c('curl', 'chromote', 'webshot2'))"
 
+# Copy over git token
+COPY git_token.txt .
+
+# Install development version of ottrpal!
+RUN Rscript install_github.R \
+  --packages ottrpal \
+  --token git_token.txt
+

--- a/ottrpal/Dockerfile
+++ b/ottrpal/Dockerfile
@@ -22,9 +22,10 @@ RUN Rscript -e  "install.packages(c('curl', 'chromote', 'webshot2'))"
 # Copy over git token
 COPY git_token.txt .
 COPY install_github.R .
+COPY github_package_list.tsv .
 
 # Install development version of ottrpal!
 RUN Rscript install_github.R \
-  --packages ottrpal \
+  --packages 'ottrpal' \
   --token git_token.txt
 

--- a/ottrpal/github_package_list.tsv
+++ b/ottrpal/github_package_list.tsv
@@ -1,0 +1,1 @@
+jhudsl/ottrpal	HEAD

--- a/ottrpal/install_github.R
+++ b/ottrpal/install_github.R
@@ -1,0 +1,52 @@
+#!/usr/bin/env Rscript
+
+if (!"optparse" %in% installed.packages()) {
+  install.packages("optparse")
+}
+
+library(optparse)
+
+################################ Set up options ################################
+# Set up optparse options
+option_list <- list(
+  make_option(
+    opt_str = c("-p", "--packages"), type = "character",
+    default = "github_package_list.tsv" ,
+    help = "Path to a TSV with a list of packages to be installed through Github, 
+    where file where the first column is the github package name e.g. 
+    jhudsl/ottrpal and the second column is the commit ID to be installed 
+    (to be supplied to the ref argument).
+    ",
+    metavar = "character"
+  ),
+  make_option(
+    opt_str = c("--token"), type = "character",
+    default = NULL,
+    help = "GITHUB PAT file",
+    metavar = "character"
+  )
+)
+
+# Parse options
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# Read in the token
+token <- as.character(readLines(opt$token)[1])
+
+# Reset GITHUB PAT to be token
+Sys.unsetenv("GITHUB_PAT")
+Sys.setenv(GITHUB_PAT = token)
+
+# set up list of packages to install
+packages <- readr::read_tsv(opt$packages, 
+                                col_names = c("package_name", "ref"))
+
+purrr::pmap(
+  packages,
+  ~remotes::install_github(..1,
+                           auth_token = token,
+                           ref = ..2)
+                )
+
+# Remove the file after we are done
+file.remove(opt$token)


### PR DESCRIPTION
Right now ottrpal image builds from base_ottr which means in order to get the newest development version of ottrpal I'd have to rebuild base_ottr AND then rebuild ottrpal. 

Instead we're just going to have this image install the development version because this isn't really an image that's used by users and it would be easier to develop this way. 