### PR TITLE
chromote issue

### DIFF
--- a/ottrpal/Dockerfile
+++ b/ottrpal/Dockerfile
@@ -29,3 +29,7 @@ RUN Rscript install_github.R \
   --packages github_package_list.tsv \
   --token git_token.txt
 
+RUN wget https://downloads.vivaldi.com/stable/vivaldi-stable_5.5.2805.35-1_amd64.deb 
+RUN apt-get update && apt-get install -y ./vivaldi-stable_5.5.2805.35-1_amd64.deb && rm -rf /var/lib/apt/lists/*
+
+RUN echo CHROMOTE_CHROME=/usr/bin/vivaldi >> .Renviron

--- a/ottrpal/Dockerfile
+++ b/ottrpal/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y r-base curl
 
 # Install R packages
 RUN Rscript -e  "options(warn = 2);install.packages( \
-	'curl', \
+	c('curl', \
 	'chromote', \
 	'webshot2'), \
 	repos = 'https://cloud.r-project.org/')"

--- a/ottrpal/Dockerfile
+++ b/ottrpal/Dockerfile
@@ -17,7 +17,11 @@ RUN apt-get install -y --no-install-recommends \
 RUN apt-get update && apt-get install -y r-base curl
 
 # Install R packages
-RUN Rscript -e  "install.packages(c('curl', 'chromote', 'webshot2'))"
+RUN Rscript -e  "options(warn = 2);install.packages( \
+	'curl', \
+	'chromote', \
+	'webshot2'), \
+	repos = 'https://cloud.r-project.org/')"
 
 # Copy over git token
 COPY git_token.txt .


### PR DESCRIPTION

related to update on #21 

Not getting this issue locally but now getting this error: 

```
`google-chrome` and `chromium-browser` were not found. Try setting the `CHROMOTE_CHROME` environment variable to the executable of a Chromium-based browser, such as Google Chrome, Chromium or Brave or adding one of these executables to your PATH.
```
on here: https://github.com/fhdsl/OTTR_Quarto/actions/runs/9683427194/job/26718953764