### PR TITLE
Rearrange order of install steps

### DIFF
--- a/base_ottr/Dockerfile
+++ b/base_ottr/Dockerfile
@@ -46,9 +46,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN Rscript -e "remove.packages('rlang')"
 
-RUN curl -LO https://quarto.org/download/latest/quarto-linux-amd64.deb
-RUN gdebi --non-interactive quarto-linux-amd64.deb
-
 # Commonly used R packages
 RUN Rscript -e  "options(warn = 2);install.packages( \
     c('rlang', \
@@ -72,6 +69,9 @@ RUN Rscript -e  "options(warn = 2);install.packages( \
       'config', \
       'quarto'), \
       repos = 'https://cloud.r-project.org/')"
+
+RUN curl -LO https://quarto.org/download/latest/quarto-linux-amd64.deb
+RUN gdebi --non-interactive quarto-linux-amd64.deb
 
 # cow needs this dependency:
 RUN Rscript -e  "devtools::install_version('gitcreds', version = '0.1.1', repos = 'http://cran.us.r-project.org')"


### PR DESCRIPTION
Getting https://github.com/jhudsl/ottrpal/actions/runs/9698477859/job/26816299898

```
Error in `quarto::quarto_render(dir)`: x Error running quarto cli.
Caused by error:
! System command 'quarto' failed
```

When I try to run quarto and I think its because the quarto needs to be installed after the R package? 

At least that's what this tutorial is showing so worth a try: https://www.r-bloggers.com/2022/07/how-to-set-up-quarto-with-docker-part-1-static-content/#google_vignette