### PR TITLE
Add webshot2 to base_ottr.

### DIFF
--- a/base_ottr/Dockerfile
+++ b/base_ottr/Dockerfile
@@ -70,7 +70,8 @@ RUN Rscript -e  "options(warn = 2);install.packages( \
       'gh', \
       'tibble', \
       'config', \
-      'quarto'), \
+      'quarto', \
+      'webshot2'), \
       repos = 'https://cloud.r-project.org/')"
 
 # cow needs this dependency:

--- a/base_ottr/Dockerfile
+++ b/base_ottr/Dockerfile
@@ -71,6 +71,7 @@ RUN Rscript -e  "options(warn = 2);install.packages( \
       'tibble', \
       'config', \
       'quarto', \
+      'chromote', \
       'webshot2'), \
       repos = 'https://cloud.r-project.org/')"
 
@@ -88,3 +89,8 @@ RUN Rscript install_github.R \
 
 # Set final workdir for commands
 WORKDIR /home/rstudio
+
+RUN wget https://downloads.vivaldi.com/stable/vivaldi-stable_5.5.2805.35-1_amd64.deb 
+RUN apt-get update && apt-get install -y ./vivaldi-stable_5.5.2805.35-1_amd64.deb && rm -rf /var/lib/apt/lists/*
+
+RUN echo CHROMOTE_CHROME=/usr/bin/vivaldi >> .Renviron


### PR DESCRIPTION
Related to this error here on ottrpal dev: https://github.com/jhudsl/ottrpal/actions/runs/9862430952/job/27232994830?pr=153 

We are working on dissolving cow and also the additional docker image of jhudsl/ottrpal. So we need to make sure that the base_ottr image has webshot2. 