### PR TITLE
Python -- try to add some common packages to the ottr_python Dockerfile

### DIFF
--- a/ottr_python/Dockerfile
+++ b/ottr_python/Dockerfile
@@ -4,3 +4,7 @@ LABEL maintainer="cansav09@gmail.com"
 # Install python
 RUN apt-get -y --no-install-recommends install \
     python3-pip  python3-dev
+
+# Install some python packages
+RUN pip3 install \
+    numpy matplotlib pandas seaborn plotnine scikit-learn scipy


### PR DESCRIPTION
Added a pip3 install command [as described in the OTTR documentation](https://www.ottrproject.org/customize-docker.html). Specifically adding these packages per Chris's request: pandas, matplotlib, seaborn, numpy, plotnine, scikit-learn, & scipy. Currently no version is specified so latest versions are being installed. Will test and specify versions later once we've verified these work.  