### PR TITLE
freeze versions for python package additions

### DIFF
--- a/ottr_python/Dockerfile
+++ b/ottr_python/Dockerfile
@@ -7,4 +7,4 @@ RUN apt-get -y --no-install-recommends install \
 
 # Install some python packages
 RUN pip3 install \
-    numpy matplotlib pandas seaborn plotnine scikit-learn scipy
+    numpy=2.0.1 matplotlib=3.9.2 pandas=2.2.2 seaborn=0.13.2 plotnine=0.13.6 scikit-learn=1.5.1 scipy=1.14.0

--- a/ottr_python/Dockerfile
+++ b/ottr_python/Dockerfile
@@ -7,4 +7,4 @@ RUN apt-get -y --no-install-recommends install \
 
 # Install some python packages
 RUN pip3 install \
-    numpy=2.0.1 matplotlib=3.9.2 pandas=2.2.2 seaborn=0.13.2 plotnine=0.13.6 scikit-learn=1.5.1 scipy=1.14.0
+    numpy==2.0.1 matplotlib==3.9.2 pandas==2.2.2 seaborn==0.13.2 plotnine==0.13.6 scikit-learn==1.5.1 scipy==1.14.0


### PR DESCRIPTION
I inspected the working docker image from #30 within docker desktop to find the versions and specified those in the dockerfile, freezing them so it's not just pulling latest. 